### PR TITLE
Introduce convenient proc-macro `#[opensbi_rt::entry]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 log = "0.4"
 spin = "0.5.2"
 linked_list_allocator = "0.8.1"
+opensbi-rt-macros = { path = "macros", version = "0.1.0" }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "opensbi-rt-macros"
+version = "0.1.0"
+authors = ["luojia65 <me@luojia.cc>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[dependencies.syn]
+version = "1.0"
+features = ["extra-traits", "full"]
+
+[dependencies.rand]
+version = "0.7"
+default-features = false
+features = ["small_rng"]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,27 +1,26 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
-use syn::{
-    parse_macro_input, parse, spanned::Spanned, 
-    FnArg, Ident, ItemFn, ReturnType, Type, Visibility,
-};
 use rand::{Rng, SeedableRng};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use syn::{
+    parse, parse_macro_input, spanned::Spanned, FnArg, Ident, ItemFn, ReturnType, Type, Visibility,
+};
 
 /// Attribute to declare the entry point of the supervisor program
-/// 
+///
 /// The specified function will be called by the runtime's init function,
 /// after a heap allocator is created. See `init` function in `src/runtime.rs`
 /// for details.
-/// 
+///
 /// Users should provide specified function with signature `fn main(usize, usize)`.
 /// For example, you may consider using `fn main(hartid: usize, dtb: usize)`.
-/// 
+///
 /// # Examples
-/// 
+///
 /// - Simple entry point
-/// 
+///
 /// ```no_run
 /// #[opensbi_rt::entry]
 /// fn main(hartid: usize, dtb: usize) {
@@ -40,9 +39,10 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
         let mut param_1_is_usize = false;
         if let FnArg::Typed(pat_type) = &f.sig.inputs[0] {
             if let Type::Path(type_path) = pat_type.ty.as_ref() {
-                if type_path.path.segments.len() == 1 
-                && type_path.path.segments[0].ident == "usize"
-                && type_path.path.segments[0].arguments.is_empty() {
+                if type_path.path.segments.len() == 1
+                    && type_path.path.segments[0].ident == "usize"
+                    && type_path.path.segments[0].arguments.is_empty()
+                {
                     param_1_is_usize = true;
                 }
             }
@@ -50,9 +50,10 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
         let mut param_2_is_usize = false;
         if let FnArg::Typed(pat_type) = &f.sig.inputs[1] {
             if let Type::Path(type_path) = pat_type.ty.as_ref() {
-                if type_path.path.segments.len() == 1 
-                && type_path.path.segments[0].ident == "usize"
-                && type_path.path.segments[0].arguments.is_empty() {
+                if type_path.path.segments.len() == 1
+                    && type_path.path.segments[0].ident == "usize"
+                    && type_path.path.segments[0].arguments.is_empty()
+                {
                     param_2_is_usize = true;
                 }
             }
@@ -61,7 +62,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     } else {
         false
     };
-    
+
     let valid_signature = f.sig.constness.is_none()
         && f.vis == Visibility::Inherited
         && f.sig.abi.is_none()

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,125 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{
+    parse_macro_input, parse, spanned::Spanned, 
+    FnArg, Ident, ItemFn, ReturnType, Type, Visibility,
+};
+use rand::{Rng, SeedableRng};
+
+// Ref: https://github.com/rust-embedded/riscv-rt/blob/master/macros/src/lib.rs
+#[proc_macro_attribute]
+pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
+    let f = parse_macro_input!(input as ItemFn);
+
+    // check the function signature
+
+    let valid_input_types = if f.sig.inputs.len() == 2 {
+        let mut param_1_is_usize = false;
+        if let FnArg::Typed(pat_type) = &f.sig.inputs[0] {
+            if let Type::Path(type_path) = pat_type.ty.as_ref() {
+                if type_path.path.segments.len() == 1 
+                && type_path.path.segments[0].ident == "usize"
+                && type_path.path.segments[0].arguments.is_empty() {
+                    param_1_is_usize = true;
+                }
+            }
+        }
+        let mut param_2_is_usize = false;
+        if let FnArg::Typed(pat_type) = &f.sig.inputs[1] {
+            if let Type::Path(type_path) = pat_type.ty.as_ref() {
+                if type_path.path.segments.len() == 1 
+                && type_path.path.segments[0].ident == "usize"
+                && type_path.path.segments[0].arguments.is_empty() {
+                    param_2_is_usize = true;
+                }
+            }
+        }
+        param_1_is_usize && param_2_is_usize
+    } else {
+        false
+    };
+    
+    let valid_signature = f.sig.constness.is_none()
+        && f.vis == Visibility::Inherited
+        && f.sig.abi.is_none()
+        && valid_input_types
+        && f.sig.generics.params.is_empty()
+        && f.sig.generics.where_clause.is_none()
+        && f.sig.variadic.is_none()
+        && match f.sig.output {
+            ReturnType::Default => true,
+            ReturnType::Type(_, ref ty) => match ty.as_ref() {
+                Type::Tuple(tuple) => tuple.elems.is_empty(),
+                _ => false,
+            },
+        };
+
+    if !valid_signature {
+        return parse::Error::new(
+            f.span(),
+            "`#[opensbi_rt::entry]` function must have signature `fn main(hartid: usize, dtb: usize)`",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    if !args.is_empty() {
+        return parse::Error::new(Span::call_site(), "This attribute accepts no arguments")
+            .to_compile_error()
+            .into();
+    }
+
+    let attrs = f.attrs;
+    let generated_name = random_ident();
+    let unsafety = f.sig.unsafety;
+    let inputs = f.sig.inputs;
+    let stmts = f.block.stmts;
+
+    quote!(
+        #[export_name = "main"]
+        #(#attrs)*
+        pub #unsafety fn #generated_name(#inputs) {
+            #(#stmts)*
+        }
+    )
+    .into()
+}
+
+static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+// Creates a random identifier
+// Ref: https://github.com/rust-embedded/riscv-rt/blob/master/macros/src/lib.rs
+fn random_ident() -> Ident {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let count: u64 = CALL_COUNT.fetch_add(1, Ordering::SeqCst) as u64;
+    let mut seed: [u8; 16] = [0; 16];
+
+    for (i, v) in seed.iter_mut().take(8).enumerate() {
+        *v = ((secs >> (i * 8)) & 0xFF) as u8
+    }
+
+    for (i, v) in seed.iter_mut().skip(8).enumerate() {
+        *v = ((count >> (i * 8)) & 0xFF) as u8
+    }
+
+    let mut rng = rand::rngs::SmallRng::from_seed(seed);
+    Ident::new(
+        &(0..16)
+            .map(|i| {
+                if i == 0 || rng.gen() {
+                    ('a' as u8 + rng.gen::<u8>() % 25) as char
+                } else {
+                    ('0' as u8 + rng.gen::<u8>() % 10) as char
+                }
+            })
+            .collect::<String>(),
+        Span::call_site(),
+    )
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -9,6 +9,26 @@ use syn::{
 };
 use rand::{Rng, SeedableRng};
 
+/// Attribute to declare the entry point of the supervisor program
+/// 
+/// The specified function will be called by the runtime's init function,
+/// after a heap allocator is created. See `init` function in `src/runtime.rs`
+/// for details.
+/// 
+/// Users should provide specified function with signature `fn main(usize, usize)`.
+/// For example, you may consider using `fn main(hartid: usize, dtb: usize)`.
+/// 
+/// # Examples
+/// 
+/// - Simple entry point
+/// 
+/// ```no_run
+/// #[opensbi_rt::entry]
+/// fn main(hartid: usize, dtb: usize) {
+///     println!("Hello, OpenSBI!");
+///     println!("hartid={}, dtb={:#x}", hartid, dtb);
+/// }
+/// ```
 // Ref: https://github.com/rust-embedded/riscv-rt/blob/master/macros/src/lib.rs
 #[proc_macro_attribute]
 pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,5 @@ pub mod io;
 mod log;
 mod runtime;
 pub mod sbi;
+
+pub use opensbi_rt_macros::entry;


### PR DESCRIPTION
This pull request introduces a new proc-macro to create entry functions conveniently, and check its function type at _compile time_ to prevent users from writing incorrect main function signatures.

Before this pull request, we would need to write like this: 

```rust
#[no_mangle]
extern "C" fn main(hartid: usize, dtb: usize) {
    // actual supervisor application code
}
```

We may write wrong function signature by mistake and this cannot be discovered by compiler. To solve this problem we introduce `#[opensbi_rt::entry]`. Now we write:

```rust
#[opensbi_rt::entry]
fn main(hartid: usize, dtb: usize) {
    // actual supervisor application code
}
```

This proc-macro is attached to function `main`. When `rustc` is parsing this code, it generates a similar function like the first code piece with `extern "C"` and `#[no_mangle]` (to achieve this it uses `export_name` instead). We may rename function `main` to any other names, it doesn't matter and the proc-macro would export it with the name `main`. Additionally it checks the function signature, including etc. paragram type and return type.

For example if I write wrong function input type, it would display a compile error:

<img width="775" alt="图片" src="https://user-images.githubusercontent.com/40385009/85685913-16e2c780-b702-11ea-8142-4daefe320efc.png">

That would help debugging and write code faster. Such a method have already been widely used by embedded rust's `*-rt` crates.

In the future if reading DTB structure is possible, we may consider allow more possible types for `dtb` variant, not `usize` only. We could check for a possible `dtb: &DeviceTree` or `dtb: *const DeviceTree` in the future.